### PR TITLE
New 2dsfs and fst

### DIFF
--- a/scripts/2dsfs_allo.symp.conf
+++ b/scripts/2dsfs_allo.symp.conf
@@ -1,0 +1,19 @@
+#   Declare 2dSFS-specific parameters here.
+#   common configuration variables are stored in common.conf
+#   Which two taxa to compute?
+TAXON1=allo
+TAXON2=symp
+#   These are files that contain the list of BAM files and inbreeding coeff.
+TAXON_LIST1=${DATA_DIR}/${TAXON1}_samples.txt
+TAXON_INBREEDING1=${DATA_DIR}/${TAXON1}_F.txt
+TAXON_LIST2=${DATA_DIR}/${TAXON2}_samples.txt
+TAXON_INBREEDING2=${DATA_DIR}/${TAXON2}_F.txt
+#   What region?
+REGIONS="12:"
+#   If you would like to change the default parameters of the analysis,
+#   you may declare the appropriate variables below.
+#   See ANGSD_2DSFS.sh for all possible parameters and their defaults
+MIN_IND1=4
+MIN_IND2=4
+N_CORES=16
+#OVERRIDE=true

--- a/scripts/NGS_FST.sh
+++ b/scripts/NGS_FST.sh
@@ -8,60 +8,74 @@ source scripts/common.conf
 # load utils functions
 source ${SCRIPTS_DIR}/utils.sh
 
-#NEED TO DO THIS: create a priorfile from pops (2D sfs): ngsPopGen/ngs2dSFS -postfiles results/og_allopatric_SFSOut.saf results/og_SFSOut.saf -outfile results/og_2dSFS.txt -relative 1 -nind 4 4
-TAXON1_LIST=${DATA_DIR}/${TAXON1}_samples.txt
-TAXON2_LIST=${DATA_DIR}/${TAXON2}_samples.txt
+#Need to have run ANGSD_2DSFS or have files in correct name format
 
-NCORES=32
-GT_LIKELIHOOD=1
-DO_SAF=1
-
-NSITES=100000
+DO_SAF=2
+UNIQUE_ONLY=0
+MIN_BASEQUAL=20
+BAQ=1
+MIN_IND1=1
+MIN_IND2=1
+GT_LIKELIHOOD=2
+MIN_MAPQ=30
+N_CORES=16
+DO_MAJORMINOR=1
+DO_MAF=1
 BLOCK_SIZE=20000
-IS_LOG=1
-RELATIVE=1
-
 
 load_config $1
 
+TAXON1_LIST=${DATA_DIR}/${TAXON1}_samples.txt
+TAXON2_LIST=${DATA_DIR}/${TAXON2}_samples.txt
+POP1_SFS=${RESULTS_DIR}/${TAXON1}_Intergenic_Conditioned.saf
+POP2_SFS=${RESULTS_DIR}/${TAXON2}_Intergenic_Conditioned.saf
+INTERSECT=${RESULTS_DIR}/intersect.${TAXON1}.${TAXON2}_intergenic.txt
+TWODSFS=${RESULTS_DIR}/2DSFS_Intergenic.${TAXON1}.${TAXON2}.sfs
 
-${ANGSD}/angsd 
-    -b ${TAXON1_LIST} 
-    -anc ${ANC_SEQ} 
-    -out ${TAXON1} 
-    -P {$N_CORES} 
-    -r ${REGIONS} 
-    -GL ${GT_LIKELIHOOD} 
-    -doSaf ${DO_SAF} 
-    -sites ${RESULTS_DIR}/${TAXON}_intersect.txt
+N_IND_1=`wc -l < ${TAXON1_LIST}`
+N_IND_2=`wc -l < ${TAXON2_LIST}`
 
-${ANGSD}/angsd 
-    -b ${TAXON2_LIST} 
-    -anc ${ANC_SEQ} 
-    -out ${TAXON1} 
-    -P {$N_CORES} 
-    -r ${REGIONS} 
-    -GL ${GT_LIKELIHOOD} 
-    -doSaf ${DO_SAF} 
-    -sites ${RESULTS_DIR}/${TAXON}_intersect.txt
+#check for sfs, intersect file, and 2dsfs from ANGSD_2DSFS
+#exit with error if any don't exist
+if file_exists "${POP1_SFS}"; then 
+    >&2 echo "WRAPPER: saf for ${TAXON1} exists, continuing to check for ${TAXON2} saf..."
+else >&2 echo "WRAPPER: saf for ${TAXON1} does not exist, exiting..." >&2; exit 1
+fi
 
-N_SITES=`wc -l ${RESULTS_DIR}/${TAXON}_intersect.txt | cut -f 1 -d " "`
-NIND1=`wc -l ${TAXON1_LIST} | cut -f 1 -d " "`
-NIND2=`wc -l ${TAXON2_LIST} | cut -f 1 -d " "`
+if file_exists "${POP2_SFS}"; then 
+    >&2 echo "WRAPPER: saf for ${TAXON2} exists, continuing to check for intersect..."
+else >&2 echo "WRAPPER: saf for ${TAXON2} does not exist, exiting..." >&2; exit 1 
+fi
 
-${NGS_POPGEN_DIR}/ngs2dSFS\
+if file_exists "${INTERSECT}"; then 
+    >&2 echo "WRAPPER: intersect exists, continuing to check for 2dsfs..."
+else >&2 echo "WRAPPER: intersect does not exist, exiting..." >&2; exit 1
+fi
+
+if file_exists "${TWODSFS}"; then 
+    >&2 echo "WRAPPER: 2dsfs exists, continuing to check for intersect..."
+else >&2 echo "WRAPPER: 2dsfs does not exist, exiting..." >&2; exit 1
+fi
+
+#make sure intersect exists
+if file_exists "${INTERSECT}"; then
+    >&2 echo "WRAPPER: Intersect exists, continuing to analysis..."
+else >&2 echo "WRAPPER: Intersect does not exist, exiting..." >&2; exit 1
+fi
+
+# get number of sites and individuals
+N_SITES=`wc -l ${INTERSECT} | cut -f 1 -d " "`
+
+# convert ANGSD 2DSFS for ngsPopGen use
+Rscript ${SCRIPTS_DIR}/convertSFS.R ${TWODSFS}\
+    > ${RESULTS_DIR}/2DSFS_Intergenic.${TAXON1}.${TAXON2}.converted.sfs
+
+# get FST
+# this is what needs the new ngsPopGen
+# make sure to change this path when wrapper is updated
+${NGS_TOOLS_DIR}/ngsPopGen/ngsFST\
     -postfiles ${POP1_SFS} ${POP2_SFS}\
-    -outfile ${RESULTS_DIR}/${TAXON}_2dSFS.txt\
-    -relative ${RELATIVE}\
-    -nind ${NIND1} ${NIND2}\
-    -nsites ${NSITES}
-
-
-${NGS_POPGEN_DIR}/ngsFST\
-    -postfiles ${POP1_SFS} ${POP2_SFS}\
-    -priorfile ${RESULTS_DIR}/${TAXON}_2dSFS.txt\
-    -nind ${NIND1} ${NIND2}\
-    -nsites ${NSITES}\
-    -block_size ${BLOCK_SIZE}\
-    -outfile ${RESULTS_DIR}/${TAXON}_pops.fst\
-    -islog ${IS_LOG}
+    -priorfile ${RESULTS_DIR}/2DSFS_Intergenic.${TAXON1}.${TAXON2}.converted.sfs\
+    -nind ${N_IND_1} ${N_IND_2}\
+    -nsites ${N_SITES}\
+    -outfile ${RESULTS_DIR}/${TAXON1}.${TAXON2}.fst

--- a/scripts/convertSFS.R
+++ b/scripts/convertSFS.R
@@ -1,0 +1,14 @@
+
+options(scipen=20)
+
+fin=commandArgs(T)
+
+sfs=exp(read.table(fin, head=F, stringsAsFactors=F))
+
+sfs[sfs<1e-10]=0
+sfs=sfs/sum(sfs)
+
+write.table(sfs, sep="\t", row.names=F, col.names=F)
+
+
+

--- a/scripts/ngsFST.conf
+++ b/scripts/ngsFST.conf
@@ -1,15 +1,24 @@
+#   NOTE: configured for use in conjunction with ANGSD_2DSFS.sh
+#   If you haven't run that yet, run that first
+#   If you already have run ANGSD to obtain a 2DSFS, 
+#   make sure you have these files named in this way:
+#   POP1_SFS=${RESULTS_DIR}/${TAXON1}_Intergenic_Conditioned
+#   POP2_SFS=${RESULTS_DIR}/${TAXON2}_Intergenic_Conditioned
+#   INTERSECT=${RESULTS_DIR}/intersect.${TAXON1}.${TAXON2}_intergenic.txt
+#   2DSFS=${RESULTS_DIR}/2DSFS_Intergenic.${TAXON1}.${TAXON2}.sfs
+
+#   You will already have these if you run ANGSD_2DSFS.sh beforehand
+
 #   ngsFST specific configuration variables go in this file.
 #   common configuration variables are in common.conf
 
 #   If you would like to change the default parameters of the analysis,
 #   you may declare the appropriate variables below.
-#   See NGSPOPGEN_NGSFST.sh for all possible parameters and their defaults
+#   See NGS_FST.sh for all possible parameters and their defaults
 
-OUTPUT=og
-POP1_SFS=results/og_allopatric_SFSOut.saf
-POP2_SFS=results/og_SFSOut.saf
-TAXON1=og_allopatric
-TAXON2=og_sympatric
-ANC_SEQ=
+#   Make sure your taxa are in the same order as they were in ANGSD_2DSFS.sh
+
+TAXON1=allo
+TAXON2=symp
 BLOCK_SIZE=20000
-IS_LOG=1
+N_CORES=16


### PR DESCRIPTION
run 2dsfs and fst in tandem to get fst. Need to update ngsPopGen to the newest version in order for fst to run. convertSFS.R from ngsTools/scripts seems to work on its own now. Make sure to change the path in the fst command when ngsPopGen is updated. change conf examples as needed. I don't have fst running in blocks right now, but that's easily added. I removed 1dsfs calls from 2dsfs since they're never called afterwards and it saves time. Added file checks in ngsfst that may or may not save time. I've had a problem with 2dsfs where I have to delete the intersect file and its bin and idx files if I rerun the same populations, but I was afraid to add that to the script because i don't want to rm people's files.