### PR TITLE
Syntax Errors with ANGSD-wrapper

### DIFF
--- a/scripts/F.conf
+++ b/scripts/F.conf
@@ -1,2 +1,3 @@
-TAXON=
-TAXON_LIST=${DATA_DIR}/${TAXON}_samples.txt
+TAXON=${HOME}/Projects/iPlant
+#TAXON_LIST=${DATA_DIR}/${TAXON}_samples.txt
+TAXON_LIST=${HOME}/angsd-wrapper/iplant/SampleNames.txt

--- a/scripts/F.sh
+++ b/scripts/F.sh
@@ -26,7 +26,7 @@ load_config $1
 N_IND=`wc -l < ${TAXON_LIST}`
 
 #check if regions exist
-if [[ ${REGIONS} == */*]]; then
+if [[ ${REGIONS} == */* ]]; then
     if file_exists "${REGIONS}" && file_not_empty "${REGIONS}"; then
         >&2 echo "WRAPPER: regions file exists and not empty, starting analysis..."
 elif variable_exists "${REGIONS}"; then

--- a/scripts/PCA.sh
+++ b/scripts/PCA.sh
@@ -22,7 +22,7 @@ load_config $1
 N_IND=`wc -l < ${TAXON_LIST}`
 
 #check if regions exist
-if [[ ${REGIONS} == */*]]; then
+if [[ ${REGIONS} == */* ]]; then
     if file_exists "${REGIONS}" && file_not_empty "${REGIONS}"; then
         >&2 echo "WRAPPER: regions file exists and not empty, starting analysis..."
 elif variable_exists "${REGIONS}"; then

--- a/scripts/SFS.conf
+++ b/scripts/SFS.conf
@@ -3,7 +3,7 @@
 #   The file containing the list of samples to analyze with ANGSD
 #   We split it up by "taxon" because it is one way to think about how to
 #   partition the data
-TAXON=
+TAXON=test
 TAXON_LIST=${DATA_DIR}/${TAXON}_samples.txt
 TAXON_INBREEDING=${DATA_DIR}/${TAXON}_F.txt
 #   If you would like to change the default parameters of the analysis,

--- a/scripts/SFS.sh
+++ b/scripts/SFS.sh
@@ -28,7 +28,7 @@ load_config $1
 #load_config ${SCRIPTS_DIR}/common.conf
 
 #check if regions exist
-if [[ ${REGIONS} == */*]]; then
+if [[ ${REGIONS} == */* ]]; then
     if file_exists "${REGIONS}" && file_not_empty "${REGIONS}"; then
         >&2 echo "WRAPPER: regions file exists and not empty, starting analysis..."
 elif variable_exists "${REGIONS}"; then

--- a/scripts/common.conf
+++ b/scripts/common.conf
@@ -17,9 +17,9 @@ DATA_DIR=${PROJECT_DIR}/data
 NGS_POPGEN_DIR=${PROJECT_DIR}/ngsPopGen
 
 #   Reference genome sequence
-#REF_SEQ=
+REF_SEQ=
 #   Ancestral sequence
-#ANC_SEQ=
+ANC_SEQ=
 #   Which regions?
 #   This can be either a chromosomal region in the form of chr:start-stop,
 #   or the path to the file containing a list of regions in the same format, one per line

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -10,7 +10,7 @@ file_exists() {
 }
 
 file_not_empty() {
-  if [[ -s "$1"]]
+  if [[ -s "$1" ]]
   then
     return 0
     echo $1" not empty!"
@@ -32,7 +32,7 @@ directory_exists() {
 }
 
 variable_exists() {
-  if [[ -n "$1"]]
+  if [[ -n "$1" ]]
   then
     return 0
     echo $1" exists!"


### PR DESCRIPTION
There were multiple syntax errors that prevented the ANGSD-wrapper from running. One of the errors was in the inbreeding coefficients script which wasn't able to run. Since many of the wrappers depend on having an inbreeding coefficient, I was not able to test most of the scripts.
### Syntax Errors

Here is a quick overview of the issues:
#### Attempt to run inbreeding coefficients script

Error message 1

```
/home/morrellp/liux1299/Arun/angsd-wrapper/scripts/utils.sh: line 13: syntax error in conditional expression
```
- fixed by adding a space before second pair of square brackets

Error message 2

```
/home/morrellp/liux1299/Arun/angsd-wrapper/scripts/utils.sh: line 35: syntax error in conditional expression
```
- fixed by adding a space before second pair of square brackets

Error message 3

```
./scripts/F.sh: line 29: syntax error in conditional expression: unexpected token `;'
```
- fixed by adding space

Error message 4

```
./scripts/F.sh: line 93: syntax error: unexpected end of file
```
- Was not able to fix this
#### Attempt to run PCA script

Error message 1

```
./scripts/PCA.sh: line 25: syntax error in conditional expression: unexpected token `;' 
```
- Fixed error by adding space before second pair of square brackets

Error message 2

```
./scripts/PCA.sh: line 68: syntax error: unexpected end of file 
```
- Was not able to fix this
#### Attempt to work through tutorial
- Error message 1
  Command used:

```
cd angsd; make
```

Tail end of error output:

```
g++ -O3 -D_USE_KNETFILE  -o angsd *.o -lz -lpthread
g++ -O3 -D_USE_KNETFILE  -o angsd.static *.o -lz -lpthread --static
/usr/bin/ld: cannot find -lz
collect2: ld returned 1 exit status
make: *** [angsd.static] Error 1
```
- The wording of what users should input for Reference and Ancestral genome sequence needs to be clarified
- `FASTA.conf` file needs to have comments
- `common.conf` file: `REF_SEQ` and `ANC_SEQ` should not be commented out. The tutorial should mention these can be edited in `common.conf`. `OVERRIDE` and `REGIONS` variables are left blank without anything assigned to them; the input users should place in those to spots is not mentioned in the tutorial.
- Use of `sbatch` should be explained in more detail because it is not available to everyone.
- After fixing the errors I could, I attempted to run ANGSD-wrapper with the following commands:

```
bash scripts/SFS.sh scripts/SFS.conf
```

And got the following error message

```
scripts/SFS.sh: line 130: syntax error: unexpected end of file
```

At this point I was not able to fix this error.
